### PR TITLE
Use jemalloc for ruby 2.3.1 PRSI-1555

### DIFF
--- a/7-ruby2.3.1-jemalloc/Dockerfile
+++ b/7-ruby2.3.1-jemalloc/Dockerfile
@@ -1,0 +1,31 @@
+FROM centos:centos7
+
+MAINTAINER services-engineering@vitals.com
+
+ENV RUBY_DIR /ruby
+ENV RUBY_VERSION 2.3.1
+ENV RUBY_INSTALL $RUBY_DIR/$RUBY_VERSION
+ENV RUBY_CONFIGURE_OPTS=--with-jemalloc
+
+RUN rpm -Uvh \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum update -y && \
+    yum install -y make which wget tar git \
+    gcc patch readline-devel zlib-devel      \
+    libyaml-devel libffi-devel openssl-devel \
+    gdbm-devel ncurses-devel libxml-devel bzip2 \
+    jemalloc-devel
+
+RUN cd /usr/src && \
+    git clone https://github.com/sstephenson/ruby-build.git && \
+    ./ruby-build/install.sh && \
+    mkdir -p $RUBY_INSTALL && \
+    /usr/local/bin/ruby-build $RUBY_VERSION $RUBY_INSTALL && \
+    rm -rf /usr/src/ruby-build
+
+ENV NODE_VERSION 5.6.0
+
+RUN wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz -O /tmp/node-v${NODE_VERSION}-linux-x64.tar.gz && \
+  tar --strip-components 1 -xzvf /tmp/node-v* -C /usr/local
+
+ENV PATH $RUBY_INSTALL/bin:$PATH


### PR DESCRIPTION
This PR opts to build a docker image for Ruby 2.3.1 using the `jemalloc` library as suggested here: https://www.levups.com/en/blog/2017/optimize_ruby_memory_usage_jemalloc_heroku_scalingo.html. 

The PRS application noticed that Sidekiq was eating an uncontrollable amount of memory. In an attempt to address this, try a different library for memory allocation